### PR TITLE
fix: 新版本的path-to-regexp不支持*匹配符

### DIFF
--- a/packages/plover/lib/util/router.js
+++ b/packages/plover/lib/util/router.js
@@ -47,6 +47,10 @@ class Router {
     options = options || {};
 
     const keys = [];
+    if (typeof pattern === 'string') {
+      // 新版本(>=2.0.0)的path-to-regexp不支持*，为了兼容需要做下替换处理
+      pattern = pattern.replace(/\/\*/g, '/(.*)');
+    }
     const regexp = pathToRegexp(pattern, keys);
     const fields = [];
     const queries = [];

--- a/packages/plover/test/util/router.js
+++ b/packages/plover/test/util/router.js
@@ -145,6 +145,17 @@ describe('util/router', function() {
   });
 
 
+  it('使用*匹配忽略的路径', function() {
+    const router = new Router();
+    router.add('/Template/*', 'template#index');
+    router.route('/Template/123').should.eql({
+      module: 'template',
+      action: 'index',
+      query: {}
+    });
+  });
+
+
   it('restful', function() {
     const router = new Router();
     router.add('/pages', 'pages:index', { method: 'get' });


### PR DESCRIPTION
https://github.com/pillarjs/path-to-regexp#compatibility-with-express--4x